### PR TITLE
Hard code project name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import os
 
 from codecs import open as copen
 from setuptools import setup
-from shmapy import __project__
+
+__project__ = "shmapy"
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/shmapy/__init__.py
+++ b/shmapy/__init__.py
@@ -1,3 +1,1 @@
-__project__ = "shmapy"
-
 from shmapy.hex_mapify import plot_hex, us_plot_hex


### PR DESCRIPTION
I overlooked this bug, sorry. `__init__.py` shouldn't have code w/ dependencies in it... **womp womp**